### PR TITLE
Update base image to bitnami/node:7.10.0-r1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/node:7.5.0-r0
+FROM bitnami/node:7.10.0-r1
 MAINTAINER Miguel Martinez <migmartri@gmail.com>
 
 COPY . /app


### PR DESCRIPTION
This also allows the container to run as a non-root user as bitnami/node no longer requires root to initialize on startup.